### PR TITLE
Added support for the Lulzbot/ebay PSU, including configurable screw types for mounting

### DIFF
--- a/scad/main.scad
+++ b/scad/main.scad
@@ -554,10 +554,10 @@ module frame_stay(left, bodge = 0) {
                     sanguinololu_screw_positions()
                         cylinder(r = M3_tap_radius, h = 100, center = true);
 
-            translate([x,  psu_y, psu_z])
+            translate([x, psu_y, psu_z])
                 rotate([0, -90, 180])
                     psu_screw_positions(psu)
-                        cylinder(r = M3_clearance_radius, h = 100, center = true);
+                        cylinder(r = psu_screw_hole_radius(psu), h = 100, center = true);
 
             //
             // Wiring holes
@@ -636,7 +636,7 @@ module electronics_assembly() {
             psu_screw_positions(psu) group() {
                 translate([0, 0, -sheet_thickness(frame)])
                     rotate([180, 0, 0])
-                        screw_and_washer(M3_cap_screw, psu_screw, true);
+                        screw_and_washer(psu_screw_type(psu), psu_screw, true);
             }
             psu(psu);
         }

--- a/scad/vitamins/electronics.scad
+++ b/scad/vitamins/electronics.scad
@@ -7,13 +7,13 @@
 //
 // Model by Václav 'ax' Hula
 //
+
 function sanguinololu_width()  = 2 * 25.4;
 function sanguinololu_length() = 4 * 25.4;
 
-
 module sanguinololu() {
     vitamin("SANGUINOL: Electronics e.g. Sanguinolou");
-	
+
     color(sanguinololu_color)
     import("../imported_stls/sanguinololu.stl");
 }
@@ -27,16 +27,36 @@ module sanguinololu_screw_positions() {
                 child();
 }
 
-KY240W = ["KY240W12L", 199, 110, 50, [[ 199 / 2 - 12,  110 / 2 - 93],
-                         [ 199 / 2 - 12,  110 / 2 - 9 ],
-                         [ 199 / 2 - 138, 110 / 2 - 93],
-                         [ 199 / 2 - 138, 110 / 2 - 9 ]]];
+KY240W =
+    ["KY240W12L", 199, 110, 50, M3_cap_screw, M3_clearance_radius,
+        [
+            [ 199 / 2 - 12,  110 / 2 - 93],
+            [ 199 / 2 - 12,  110 / 2 - 9 ],
+            [ 199 / 2 - 138, 110 / 2 - 93],
+            [ 199 / 2 - 138, 110 / 2 - 9 ]
+        ]
+    ];
 
-function psu_name(type)   = type[0];
-function psu_length(type) = type[1];
-function psu_width(type)  = type[2];
-function psu_height(type) = type[3];
-function psu_hole_list(type) = type[4];
+// This PSU, and ones very like it, are sold by LulzBot, and various sellers on eBay.
+// The screw layout specified here uses the inner set of screw-mounts on the PSU, which are M4.
+// The outer set don't appear to be M3, even though the datasheet claims they are.
+S_300_12 =
+    ["S30012", 215, 115, 50, M4_cap_screw, M4_clearance_radius,
+        [
+            [ 215 / 2 - 32.5,  115 / 2 - 82.5],
+            [ 215 / 2 - 32.5,  115 / 2 - 32.5 ],
+            [ 215 / 2 - 182.5, 115 / 2 - 82.5],
+            [ 215 / 2 - 182.5, 115 / 2 - 32.5 ]
+        ]
+    ];
+
+function psu_name(type)              = type[0];
+function psu_length(type)            = type[1];
+function psu_width(type)             = type[2];
+function psu_height(type)            = type[3];
+function psu_screw_type(type)        = type[4];
+function psu_screw_hole_radius(type) = type[5];
+function psu_hole_list(type)         = type[6];
 
 module psu(type) {
     vitamin(str(psu_name(type),": PSU e.g. ", psu_name(type)));


### PR DESCRIPTION
My PSU appears to be similar to the KY230W, but has slightly different dimensions and a different screw pattern.  This variant of PSU seems to be fairly common in the US, and probably warrants addition to the core repo.

These changes have been validated by a run of "make_machine.py mendel" and  a render with OpenSCAD.
