### PR TITLE
Fix bar clamp bridging with M4 screws

### DIFF
--- a/scad/bar-clamp.scad
+++ b/scad/bar-clamp.scad
@@ -52,7 +52,7 @@ module bar_clamp(d, h, w, switch = false, yaxis = false) {
 
     cavity_l = stem - 2 * wall;
     cavity_h = h - nut_trap_meat - nut_trap_depth;
-    cavity_w = w - 2 * wall;
+    cavity_w = max(w - 2 * wall, nut_radius * 2);
 
     sbracket_length = -y_switch_x(w) + 4;
     sbracket_thickness = 7;


### PR DESCRIPTION
When using M4 screws, the cavity was to small causing the bridging to fail. This commit fixes that.