### PR TITLE
Add disposable material to help x carriage fan duct stay attached during...

### DIFF
--- a/scad/x-carriage.scad
+++ b/scad/x-carriage.scad
@@ -289,6 +289,10 @@ module x_carriage_fan_duct_stl() {
 
     difference() {
         union() {
+            translate([0,0,layer_height / 2]) union() {
+                cube([or * 2 - duct_wall, 3, layer_height], center=true);
+                cube([3, or * 2 - duct_wall, layer_height], center=true);
+            }
             difference() {
                 union() {
                     // fan input


### PR DESCRIPTION
... printing. The inner part of the duct has very little contact surface with the build platform. This version has a single-layer-thick connection between the inner and outer parts to help hold it down. The connection carries right across the middle so it is obvious that it should be removed before fitting.
