### PR TITLE
Support non-square print bed.

### DIFF
--- a/scad/bed.scad
+++ b/scad/bed.scad
@@ -15,14 +15,14 @@ module bed_assembly(y = 0) {
     //
     // Screws pillars and washers
     //
-    for(x = [-bed_holes / 2, bed_holes /2]) {
-        translate([x, bed_holes / 2, 0])
+    for(x = [-X_bed_holes / 2, X_bed_holes /2]) {
+        translate([x, Y_bed_holes / 2, 0])
             washer(M3_washer);
 
-        translate([x, -bed_holes / 2 - washer_diameter(M3_washer) / 2 - 3 / 2, 0])
+        translate([x, -Y_bed_holes / 2 - washer_diameter(M3_washer) / 2 - 3 / 2, 0])
             washer(M3_washer);
 
-        for(y = [-bed_holes / 2, bed_holes /2])
+        for(y = [-Y_bed_holes / 2, Y_bed_holes /2])
             translate([x, y, washer_thickness(M3_washer)]) {
                 hex_pillar(bed_pillars);
 

--- a/scad/conf/dibond_config.scad
+++ b/scad/conf/dibond_config.scad
@@ -28,7 +28,8 @@ bed_width = 214;
 bed_pillars = M3x20_pillar;
 bed_glass = glass2;
 bed_thickness = pcb_thickness + sheet_thickness(bed_glass);    // PCB heater plus glass sheet
-bed_holes = 209;
+X_bed_holes = 209;
+Y_bed_holes = 209;
 
 base = DiBond;                  // Sheet material used for the base. Needs to be thick enough to screw into.
 base_corners = 25;
@@ -58,8 +59,8 @@ Y_belt = T2p5x6;
 motor_shaft = 5;
 Z_screw_dia = 6;            // Studding for Z axis
 
-Y_carriage_depth = bed_holes + 7;
-Y_carriage_width = bed_holes + 7;
+Y_carriage_depth = Y_bed_holes + 7;
+Y_carriage_width = X_bed_holes + 7;
 
 Z_nut_radius = M6_nut_radius;
 Z_nut_depth = M6_nut_depth;

--- a/scad/conf/huxley_config.scad
+++ b/scad/conf/huxley_config.scad
@@ -28,7 +28,8 @@ bed_width = 150 + 14;
 bed_pillars = M3x20_pillar;
 bed_glass = glass2;
 bed_thickness = pcb_thickness + sheet_thickness(bed_glass);    // PCB heater plus glass sheet
-bed_holes = bed_width - 5;
+X_bed_holes = bed_width - 5;
+Y_bed_holes = bed_depth - 5;
 
 base = DiBond;                  // Sheet material used for the base. Needs to be thick enough to screw into.
 base_corners = 25;
@@ -57,8 +58,8 @@ Y_belt = T2p5x6;
 motor_shaft = 5;
 Z_screw_dia = 6;            // Studding for Z axis
 
-Y_carriage_depth = bed_holes + 7;
-Y_carriage_width = bed_holes + 7;
+Y_carriage_depth = Y_bed_holes + 7;
+Y_carriage_width = X_bed_holes + 7;
 
 Z_nut_radius = M6_nut_radius;
 Z_nut_depth = M6_nut_depth;

--- a/scad/conf/mendel_config.scad
+++ b/scad/conf/mendel_config.scad
@@ -28,7 +28,8 @@ bed_width = 214;
 bed_pillars = M3x20_pillar;
 bed_glass = glass2;
 bed_thickness = pcb_thickness + sheet_thickness(bed_glass);    // PCB heater plus glass sheet
-bed_holes = 209;
+X_bed_holes = 209;
+Y_bed_holes = 209;
 
 base = PMMA10;               // Sheet material used for the base. Needs to be thick enough to screw into.
 base_corners = 25;
@@ -58,8 +59,8 @@ Y_belt = T5x6;
 motor_shaft = 5;
 Z_screw_dia = 8;            // Studding for Z axis
 
-Y_carriage_depth = bed_holes + 8;
-Y_carriage_width = bed_holes + 8;
+Y_carriage_depth = Y_bed_holes + 8;
+Y_carriage_width = X_bed_holes + 8;
 
 Z_nut_radius = M8_nut_radius;
 Z_nut_depth = M8_nut_depth;

--- a/scad/conf/sturdy_config.scad
+++ b/scad/conf/sturdy_config.scad
@@ -28,7 +28,8 @@ bed_width = 214;
 bed_pillars = M3x20_pillar;
 bed_glass = glass2;
 bed_thickness = pcb_thickness + sheet_thickness(bed_glass);    // PCB heater plus glass sheet
-bed_holes = 209;
+X_bed_holes = 209;
+Y_bed_holes = 209;
 
 base = MDF12;
 base_corners = 0;
@@ -57,8 +58,8 @@ Y_belt = T5x6;
 motor_shaft = 5;
 Z_screw_dia = 8;            // Studding for Z axis
 
-Y_carriage_depth = bed_holes + 8;
-Y_carriage_width = bed_holes + 8;
+Y_carriage_depth = Y_bed_holes + 8;
+Y_carriage_width = X_bed_holes + 8;
 
 Z_nut_radius = M8_nut_radius;
 Z_nut_depth = M8_nut_depth;

--- a/scad/main.scad
+++ b/scad/main.scad
@@ -269,8 +269,8 @@ module y_carriage() {
                     y_belt_anchor_holes()
                         cylinder(r = M3_clearance_radius, h = 100, center = true);
 
-        for(x = [-bed_holes / 2, bed_holes / 2])
-            for(y = [-bed_holes / 2, bed_holes / 2])
+        for(x = [-X_bed_holes / 2, X_bed_holes / 2])
+            for(y = [-Y_bed_holes / 2, Y_bed_holes / 2])
                 translate([x, y, 0])
                     cylinder(r = 2.5/2, h = 100, center = true);
     }


### PR DESCRIPTION
While you can currently attempt to specify non-square print surfaces using bed_width and bed_depth, the y carriage is always square. This patch separates out Y carriage hole spacing for X and Y directions, allowing proper use of non-square beds, e.g. Makerfarm 8.4" x 12.6" Heat Bed.
