### PR TITLE
y motor wires should face the back

### DIFF
--- a/scad/y-motor-bracket.scad
+++ b/scad/y-motor-bracket.scad
@@ -95,7 +95,7 @@ module y_motor_assembly() {
     //
     // Motor and screws
     //
-    rotate([0, 0, 90])
+    rotate([0, 0, base_nuts ? 180 : 90])
         NEMA(Y_motor);
     translate([0,0, thickness])
         NEMA_screws(Y_motor);


### PR DESCRIPTION
Hi Chris, I'm pretty sure this needed fixing. In master, the y motor wires faced down, directly into the sheet. This change makes them face toward the back of the machine, as the instructions in the wiki indicate they should.
