### PR TITLE
add support for Python 3.2 and 3.3, retain backward compatibility

### DIFF
--- a/InkCL.py
+++ b/InkCL.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python
 #from http://kaioa.com/node/42
 
+from __future__ import print_function
+
 import os, subprocess, sys
 
+
 def run(*args):
-    print "inkscape",
+    print("inkscape", end=" ")
     for arg in args:
-        print arg,
-    print
+        print(arg, end=" ")
+    print()
     run = subprocess.Popen(["inkscape"] + list(args) + [" -z"], shell = False, stdout = subprocess.PIPE, stderr = subprocess.PIPE)
     out,err=[e.splitlines() for e in run.communicate()]
     return run.returncode, out, err
@@ -15,8 +18,8 @@ def run(*args):
 if __name__=='__main__':
     r = run(sys.argv[1:])
     if not r[0]==0:
-        print 'return code:',r[0]
+        print('return code:', r[0])
     for l in r[1]:
-        print l
+        print(l)
     for l in r[2]:
-        print l
+        print(l)

--- a/bom.py
+++ b/bom.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+
 import os
 import sys
 import shutil
 import openscad
+
 
 class BOM:
     def __init__(self):
@@ -34,7 +37,7 @@ class BOM:
         return ass.replace("assembly", "assemblies")
 
     def print_bom(self, breakdown, file = None):
-        print >> file, "Vitamins:"
+        print("Vitamins:", file=file)
         if breakdown:
             longest = 0
             for ass in self.assemblies:
@@ -45,10 +48,10 @@ class BOM:
                     name = ass.replace("_assembly","").replace("_"," ").capitalize()
                     index = i - (longest - len(name))
                     if index < 0:
-                        print >> file, "  ",
+                        print("  ", end=" ", file=file)
                     else:
-                        print >> file, " %s" % name[index],
-                print >> file
+                        print(" %s" % name[index], end=" ", file=file)
+                print(file=file)
 
         for part in sorted(self.vitamins):
             if ': ' in part:
@@ -62,10 +65,10 @@ class BOM:
                         file.write("%2d|" % bom.vitamins[part])
                     else:
                         file.write("  |")
-            print >> file, "%3d" % self.vitamins[part], description
+            print("%3d" % self.vitamins[part], description, file=file)
 
-        print >> file
-        print >> file, "Printed:"
+        print(file=file)
+        print("Printed:", file=file)
         for part in sorted(self.printed):
             if breakdown:
                 for ass in sorted(self.assemblies):
@@ -74,13 +77,13 @@ class BOM:
                         file.write("%2d|" % bom.printed[part])
                     else:
                         file.write("  |")
-            print >> file, "%3d" % self.printed[part], part
+            print("%3d" % self.printed[part], part, file=file)
 
-        print >> file
+        print(file=file)
         if self.assemblies:
-            print >> file, "Sub-assemblies:"
+            print("Sub-assemblies:", file=file)
         for ass in sorted(self.assemblies):
-            print  >> file, "%3d %s" % (self.assemblies[ass].count, self.assemblies[ass].make_name(ass))
+            print("%3d %s" % (self.assemblies[ass].count, self.assemblies[ass].make_name(ass)), file=file)
 
 def boms(machine):
     bom_dir = machine + "/bom"
@@ -93,7 +96,7 @@ def boms(machine):
     f.close()
 
     openscad.run("-D","$bom=2","-o", "dummy.csg", "scad/bom.scad")
-    print "Generating bom ...",
+    print("Generating bom ...", end=" ")
 
     main = BOM()
     stack = []
@@ -110,7 +113,7 @@ def boms(machine):
             else:
                 if s[0] == '/':
                     if s[1:] != stack[-1]:
-                        raise Exception, "Mismatched assembly " + s[1:] + str(stack)
+                        raise Exception("Mismatched assembly " + s[1:] + str(stack))
                     stack.pop()
                 else:
                     main.add_part(s)
@@ -122,15 +125,15 @@ def boms(machine):
     for ass in sorted(main.assemblies):
         f = open(bom_dir + "/" + ass + ".txt", "wt");
         bom = main.assemblies[ass]
-        print >> f, bom.make_name(ass) + ":"
+        print(bom.make_name(ass) + ":", file=f)
         bom.print_bom(False, f)
         f.close()
 
-    print " done"
+    print(" done")
 
 if __name__ == '__main__':
     if len(sys.argv) > 1:
         boms(sys.argv[1])
     else:
-        print "usage: bom [mendel|sturdy|your_machine]"
+        print("usage: bom [mendel|sturdy|your_machine]")
         sys.exit(1)

--- a/c14n_stl.py
+++ b/c14n_stl.py
@@ -5,7 +5,11 @@
 # It then sorts the triangles to start with the one with the lowest vertices first (comparing first vertex, second, then third)
 # This has no effect on the model but makes the STL consistent. I.e. it makes a canonical form.
 #
+
+from __future__ import print_function
+
 import sys
+
 
 class Vertex:
     def __init__(self, x, y, z):
@@ -55,20 +59,20 @@ class STL:
 
             self.facets.sort(key = Facet.key)
         else:
-            print "Not an OpenSCAD ascii STL file"
+            print("Not an OpenSCAD ascii STL file")
             sys.exit(1)
 
     def write(self, fname):
         f = open(fname,"wt")
-        print >> f,'solid OpenSCAD_Model'
+        print('solid OpenSCAD_Model', file=f)
         for facet in self.facets:
-            print >> f, '  facet normal %s %s %s' % (facet.normal.dx, facet.normal.dy, facet.normal.dz)
-            print >> f, '    outer loop'
+            print('  facet normal %s %s %s' % (facet.normal.dx, facet.normal.dy, facet.normal.dz), file=f)
+            print('    outer loop', file=f)
             for vertex in facet.vertices:
-                print >> f, '      vertex %s %s %s' % (vertex.x, vertex.y, vertex.z)
-            print  >> f, '    endloop'
-            print  >> f, '  endfacet'
-        print >> f, 'endsolid OpenSCAD_Model'
+                print('      vertex %s %s %s' % (vertex.x, vertex.y, vertex.z), file=f)
+            print('    endloop', file=f)
+            print('  endfacet', file=f)
+        print('endsolid OpenSCAD_Model', file=f)
         f.close()
 
 def canonicalise(fname):
@@ -79,5 +83,5 @@ if __name__ == '__main__':
     if len(sys.argv) == 2:
         canonicalise(sys.argv[1])
     else:
-        print "usage: c14n_stl file"
+        print("usage: c14n_stl file")
         sys.exit(1)

--- a/dxf.py
+++ b/dxf.py
@@ -7,9 +7,9 @@ def parse_dxf(fn):
     f = open(fn)
 
     # skip to entities section
-    s = f.next()
+    s = next(f)
     while s.strip() != 'ENTITIES':
-        s = f.next()
+        s = next(f)
 
     in_line = False
     in_circle = False
@@ -27,8 +27,8 @@ def parse_dxf(fn):
             keys = dict.fromkeys(['8','10','20','30','11','21','31'], 0.0)
             while line != '0':
                 if line in keys:
-                    keys[line] = float(f.next().strip())
-                line = f.next().strip()
+                    keys[line] = float(next(f).strip())
+                line = next(f).strip()
             pt_list.append( ((keys['10'], keys['20']), (keys['11'], keys['21'])) )
             in_line = False
 
@@ -36,8 +36,8 @@ def parse_dxf(fn):
             keys = dict.fromkeys(['8','10','20','30','40'], 0.0)
             while line != '0':
                 if line in keys:
-                    keys[line] = float(f.next().strip())
-                line = f.next().strip()
+                    keys[line] = float(next(f).strip())
+                line = next(f).strip()
             cir_list.append([[keys['10'], keys['20'], keys['30']], keys['40']])
             in_circle = False
 
@@ -102,7 +102,7 @@ def dxf_to_svg(fn):
     xmin = ymin = 99999999
     for loop in loops:
         if len(loop) < 4 or loop[0] != loop[-1]:
-            raise Exception, "loop not closed " + str(loop)
+            raise Exception("loop not closed " + str(loop))
         for point in loop:
             if point[0] > xmax: xmax = point[0]
             if point[0] < xmin: xmin = point[0]
@@ -111,7 +111,7 @@ def dxf_to_svg(fn):
 
     def p(x, y): return (x - xmin, ymax - y)
 
-    print xmin, ymin, xmax, ymax
+    print(xmin, ymin, xmax, ymax)
     scene = Scene(fn[:-4], ceil(ymax - ymin + 10), ceil(xmax - xmin + 10))
     for loop in loops:
         circle = is_circle(loop)

--- a/make_machine.py
+++ b/make_machine.py
@@ -16,5 +16,5 @@ if __name__ == '__main__':
     if len(sys.argv) > 1:
         make_machine(sys.argv[1])
     else:
-        print "usage: make_machine [mendel|sturdy|your_machine]"
+        print("usage: make_machine [mendel|sturdy|your_machine]")
         sys.exit(1)

--- a/openscad.py
+++ b/openscad.py
@@ -1,10 +1,13 @@
+from __future__ import print_function
+
 import subprocess
 
+
 def run(*args):
-    print "openscad",
+    print("openscad", end=" ")
     for arg in args:
-        print arg,
-    print
+        print(arg, end=" ")
+    print()
     log = open("openscad.log", "w")
     subprocess.call(["openscad"] + list(args), stdout = log, stderr = log)
     log.close()

--- a/plates.py
+++ b/plates.py
@@ -50,11 +50,11 @@ def plates(machine):
             if os.path.isfile(path):
                 shutil.copy(path, target_dir + "/" + file)
             else:
-                print "can't find %s to copy" % path
+                print("can't find %s to copy" % path)
 
 if __name__ == '__main__':
     if len(sys.argv) > 1:
         plates(sys.argv[1])
     else:
-        print "usage: plates [mendel|sturdy|your_machine]"
+        print("usage: plates [mendel|sturdy|your_machine]")
         sys.exit(1)

--- a/sheets.py
+++ b/sheets.py
@@ -70,5 +70,5 @@ if __name__ == '__main__':
     if len(sys.argv) > 1:
         sheets(sys.argv[1])
     else:
-        print "usage: sheets [mendel|sturdy|your_machine]"
+        print("usage: sheets [mendel|sturdy|your_machine]")
         sys.exit(1)

--- a/stls.py
+++ b/stls.py
@@ -87,12 +87,12 @@ def stls(machine, parts = None):
     # List the ones we didn't find
     #
     for module in targets:
-        print "Could not find", module
+        print("Could not find", module)
     return used
 
 if __name__ == '__main__':
     if len(sys.argv) > 1:
         stls(sys.argv[1], sys.argv[2:])
     else:
-        print "usage: stls [mendel|sturdy|your_machine] [part.stl ...]"
+        print("usage: stls [mendel|sturdy|your_machine] [part.stl ...]")
     sys.exit(1)


### PR DESCRIPTION
This updates the Python scripts to work with the latest Python (3.3), and continues to support 2.6 and 2.7. Most of the changes are just to use the print function instead of the special syntax used in 2.x.
