### PR TITLE
Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ language: python
 python:
  - "2.6"
  - "2.7"
+ - "3.2"
+ - "3.3"
 before_install:
  - sudo add-apt-repository -y ppa:chrysn/openscad
  - sudo apt-get update -qq


### PR DESCRIPTION
This is a basic Travis configuration [I was using](https://travis-ci.org/brad/Mendel90) to make sure my updates for #43 worked. All it does is install the latest version of Openscad from the PPA and build the dibond and sturdy variants of Mendel90 (I tried doing the mendel variant as well, but all three variants take too long and Travis kills the build).

Travis will let you know if anything went wrong with the build, whether it be openscad or python errors. With #42, you can easily add a build badge that displays the build status to the README. Another great benefit of Travis is that it's integrated with Github to let you know if pull requests build successfully (only pull requests submitted after getting the .travis.yml into master).
