### PR TITLE
Fix hot end screw2

### DIFF
--- a/scad/wade.scad
+++ b/scad/wade.scad
@@ -40,15 +40,16 @@ filament_z = 13;
 
 extension = max(0, nozzle_length - hot_end_length(hot_end));
 extension_width = 30;
+extension_clearance = 1;
 
 jhead_screw = M3_cap_screw;
-jhead_screw_length = 16;
 jhead_washer = M4_washer;
+jhead_nut_slot = nut_thickness(screw_nut(jhead_screw)) + 0.3;
+jhead_screw_length = 16;
 jhead_screw_pitch = max(hot_end_insulator_diameter(hot_end) / 2 + screw_head_radius(jhead_screw),
                           jhead_groove_dia() / 2 + washer_diameter(jhead_washer) / 2);
 
 extension_rad = jhead_screw_pitch + 5;
-extension_clearance = 1;
 
 pscrew_y = [17.5, 45.5];
 pscrew_z = [filament_z - 6.5, filament_z + 6.5];
@@ -84,7 +85,6 @@ module keyhole(r, h, l) {
 nut_inset = min_wall;
 
 jhead_screw_angle = 5;
-jhead_nut_slot = nut_thickness(screw_nut(jhead_screw)) + 0.3;
 
 module wades_block_stl() {
     stl("wades_block");

--- a/scad/wade.scad
+++ b/scad/wade.scad
@@ -45,7 +45,7 @@ extension_clearance = 1;
 jhead_screw = M3_cap_screw;
 jhead_washer = M4_washer;
 jhead_nut_slot = nut_thickness(screw_nut(jhead_screw)) + 0.3;
-jhead_screw_length = 16;
+jhead_screw_length = screw_longer_than(base_thickness + extension + jhead_nut_slot + washer_thickness(jhead_washer) + washer_thickness(screw_washer(jhead_screw)));
 jhead_screw_pitch = max(hot_end_insulator_diameter(hot_end) / 2 + screw_head_radius(jhead_screw),
                           jhead_groove_dia() / 2 + washer_diameter(jhead_washer) / 2);
 

--- a/scad/wade.scad
+++ b/scad/wade.scad
@@ -226,7 +226,7 @@ module wades_block_stl() {
                          rotate([0, 0, i * 120 + jhead_screw_angle])
                             translate([jhead_screw_pitch, 0, 0])
                                 rotate([0, 0, -i * 120 - jhead_screw_angle]) {
-                                    teardrop_plus(r = screw_clearance_radius(jhead_screw), h = jhead_screw_length * 2, center = true);
+                                    teardrop_plus(r = screw_clearance_radius(jhead_screw), h = (base_thickness + extension + jhead_nut_slot + 6) * 2, center = true);
                                     translate([0, 0, -base_thickness - extension - jhead_nut_slot / 2]) {
                                         rotate([0, 0, [0, 30, 30][i]])
                                             nut_trap(0, nut_radius(screw_nut(jhead_screw)), jhead_nut_slot / 2, horizontal = true);


### PR DESCRIPTION
This branch takes into account the suggestion from the previous merge request.
The 3rd commit (6cb99e4) allows to keep a constant hole size whatever the chosen length of screw, and migth be removed.
Tested with “eyes” changing several parameters (jhead_total_length, extension_clearence, jhead_screw_pitch, …)