### PR TITLE
E3d same duct

### DIFF
--- a/scad/conf/config.scad
+++ b/scad/conf/config.scad
@@ -81,7 +81,7 @@ pcb_thickness = 1.6;
 feed_tube_rad = 5 / 2;              // Filament feed tube
 feed_tube_tape_rad = 6.2 / 2;
 feed_tube_tape = 12;
-nozzle_length = 54;                 // how far nozzle is below top of carriage
+function nozzle_length(hot_end) = max(54, hot_end_length(hot_end));      // how far nozzle is below top of carriage. Can be more than that if the hot end is bigger
 
 
 include <colors.scad>

--- a/scad/conf/utils.scad
+++ b/scad/conf/utils.scad
@@ -122,12 +122,17 @@ module rounded_rectangle(size, r, center = true)
 //
 module rounded_cylinder(r, h, r2)
 {
+    r2=min(h, r2, r);
     rotate_extrude()
         union() {
             square([r - r2, h]);
             square([r, h - r2]);
             translate([r - r2, h - r2])
-                circle(r = r2);
+                difference() {
+                    circle(r = r2);
+                    translate([-r2, -r2]) square([2*r2, r2]);
+                    translate([-r2, -r2]) square([r2, 2*r2]);
+                }
         }
 }
 

--- a/scad/positions.scad
+++ b/scad/positions.scad
@@ -23,7 +23,7 @@ Y_carriage_height = y_motor_bracket_height() + X_carriage_clearance + sheet_thic
 
 bed_height =  Y_carriage_height + sheet_thickness(Y_carriage) / 2 + pillar_height(bed_pillars) + washer_thickness(M3_washer) + bed_thickness;
 
-Z0 = floor(bed_height + nozzle_length - x_carriage_offset());
+Z0 = floor(bed_height + nozzle_length(hot_end) - x_carriage_offset());
 
 height = ceil(Z0 + Z_travel + limit_switch_offset + x_end_height() + bar_clamp_depth + axis_end_clearance + base_clearance);
 

--- a/scad/vitamins/e3d_hot_end.scad
+++ b/scad/vitamins/e3d_hot_end.scad
@@ -1,0 +1,148 @@
+//
+// Mendel90
+//
+
+include <../conf/config.scad>
+
+groove_dia = 12;
+groove_h = 6;
+
+rad_dia = 22; // Diam of the part with ailettes
+rad_nb_ailettes = 11;
+rad_len = 26;
+
+nozzle_h = 5;
+
+module e3d_nozzle(type) {
+    color("gold")
+    difference() {
+        union() {
+            cylinder(r1=1.3/2, r2=3/2, h=2);
+            translate([0, 0, 2]) cylinder(r = 8/2, h=nozzle_h-2, $fn=6);
+        }
+        translate([0, 0, -eta]) cylinder(d=0.5, h=nozzle_h+ 2*eta);
+    }
+}
+
+resistor_len = 22;
+resistor_dia = 6;
+
+heater_width  = 16;
+heater_length = 20;
+heater_height = 11.5;
+
+heater_x = 4.5;
+heater_y = heater_width / 2;
+
+fan_x_offset = rad_dia/2 + 4;
+
+module e3d_resistor(type) {
+    translate([11-heater_x, -3-heater_y, heater_height/2+nozzle_h]) {
+        color("grey") rotate([-90, 0, 0]) cylinder(d=resistor_dia, h=resistor_len);
+        color("red") translate([-3.5/2, resistor_len  + 3.5/2  +1, 0]) {
+            cylinder(d=3.5, h=36);
+            translate([3.5, 0, 0]) cylinder(d=3.5, h=36);
+        }
+
+
+    }
+}
+
+module heater_block(type) {
+    translate([0, 0, -hot_end_length(type)])  {
+        translate([0, 0, nozzle_h]) difference() {
+            color("lightgrey") union() {
+                // Heat break
+                cylinder(d=4, h=heater_height + 10);
+                translate([-heater_x, -heater_y, 0])  {
+                    cube([heater_length, heater_width, heater_height]);
+                }
+            }
+            cylinder(d=3, h=heater_height + 10 + eta); // Filament hole
+        }
+
+        e3d_resistor(type);
+        e3d_nozzle(type);
+    }
+}
+
+
+
+module e3d_rad(type) {
+    h_ailettes = rad_len / (2*rad_nb_ailettes -1);
+
+    difference() {
+        cylinder(r=rad_dia/2, h=rad_len);
+
+        translate([0, 0, -eta]) cylinder(r=hot_end_insulator_diameter(type)/2-eta, h=rad_len+2*eta);
+
+        for ( i = [0:rad_nb_ailettes-2] ) {
+            translate([0, 0, (2*i +1) * h_ailettes])
+            cylinder(r=rad_dia, h=h_ailettes);
+        }
+    }
+}
+
+module e3d_fan_duct(type) {
+    color("DeepSkyBlue")
+    difference() {
+        hull() {
+            translate([-8, -23/2, 0]) cube([eta, 23, 26]);
+            translate([fan_x_offset, -30/2, 0]) cube([eta, 30, 30]);
+        }
+        cylinder(h=70, d=rad_dia+0.1, center=true); // For rad
+        translate([0, 0, 15])  rotate([0, 90, 0]) cylinder(d=rad_dia, h=50);
+    }
+}
+
+module e3d_fan(type) {
+    e3d_fan_duct(type);
+    translate([fan_x_offset+5, 0, 15]) rotate([0, 90, 0]) color("darkgrey") fan(fan30x10);
+}
+
+module e3d_hot_end(type) {
+    insulator_length = hot_end_insulator_length(type);
+    inset = hot_end_inset(type);
+    bundle = 3.2;
+    tape_thickness = 0.8;
+
+    vitamin(hot_end_part(type));
+    vitamin("ST25110: 110mm x 25mm self amalgamating silicone tape");
+
+    translate([0, 0, inset - insulator_length]) {
+        color(hot_end_insulator_colour(type)) render(convexity = 10) {
+            difference() {
+                cylinder(r = hot_end_insulator_diameter(type) / 2, h = insulator_length);
+                cylinder(r = 3.2 / 2, h = insulator_length * 2 + 1, center = true);  // Filament hole
+                translate([0, 0, insulator_length - hot_end_inset(type) - groove_h / 2])
+                    tube(ir = groove_dia / 2, or = hot_end_insulator_diameter(type) / 2 + eta, h = groove_h);
+            }
+            e3d_rad(e3d_china);
+        }
+    }
+
+
+    // Wire and ziptie
+    rotate([0, 0, 10]) {
+        scale([1, (bundle + hot_end_insulator_diameter(type)) / hot_end_insulator_diameter(type)])
+                translate([0, -bundle / 2, -7])
+            rotate([0, 0, -110])
+                    ziptie(small_ziptie, hot_end_insulator_diameter(type) / 2);
+
+        translate([0, -hot_end_insulator_diameter(type) / 2 - bundle / 2, 20])
+            scale([0.7, bundle / 6.4])
+                difference() {
+                    tubing(HSHRNK64, 60);
+                    translate([0, 0, 20])
+                    cube([10, 10, 60], center = true);
+                }
+
+    }
+
+    rotate([0, 0, 90]) heater_block(type);
+
+    translate([0, 0, inset - insulator_length]) e3d_fan();
+
+}
+
+e3d_hot_end(e3d_china);

--- a/scad/vitamins/hot_ends.scad
+++ b/scad/vitamins/hot_ends.scad
@@ -9,6 +9,7 @@
 Stoffel = 1;
 m90     = 2;
 jhead   = 3;
+e3d     = 4;
 
 m90_hot_end_12mm    = [m90,      "HEM90340: Mendel 90 hot end", 57, 10,          12,    40, "tan", 6     + 3/2 - 1, false];
 m90_hot_end_12p5mm  = [m90,      "HEM90340: Mendel 90 hot end", 57, 10,          12.5,  40, "tan", 6.25  + 3/2 - 1, false];
@@ -16,6 +17,10 @@ m90_hot_end_12p75mm = [m90,      "HEM90340: Mendel 90 hot end", 57, 10,         
 
 JHeadMk4 =            [jhead,   "HEJH16340: JHead MK4 hot end", 64, 5.1,         16,    50, "black", 12,            true, 4.64, 10.19 + 4, [0, 2.94, -5]];
 JHeadMk5 =            [jhead,   "HEJH16340: JHead MK5 hot end", 54, 5.1,         16,    40, "black", 12,            true, 4.64, 9     + 4, [0, 2.38, -5]];
+
+e3dv6 =               [e3d,     "e3d V6 3mm direct",            62, 3.7,         16,  42.7, "lightgrey",  12,       true,    6,        15, [1, 5, -5]];
+e3dv5 =               [e3d,     "e3d V5 3mm direct",            70, 3.7,         16,  50.1, "lightgrey",  12,       true,    6,        15, [1, 5, -5]];
+e3d_clone =           [e3d,     "e3d clone aliexpress",         66, 6.8,         16,    46, "lightgrey",  12,       true,  5.6,        15, [1, 5, -5]];
 
 function hot_end_style(type)              = type[0];
 function hot_end_part(type)               = type[1];

--- a/scad/vitamins/hot_ends.scad
+++ b/scad/vitamins/hot_ends.scad
@@ -15,12 +15,12 @@ m90_hot_end_12mm    = [m90,      "HEM90340: Mendel 90 hot end", 57, 10,         
 m90_hot_end_12p5mm  = [m90,      "HEM90340: Mendel 90 hot end", 57, 10,          12.5,  40, "tan", 6.25  + 3/2 - 1, false];
 m90_hot_end_12p75mm = [m90,      "HEM90340: Mendel 90 hot end", 57, 10,          12.75, 40, "tan", 6.375 + 3/2 - 1, false];
 
-JHeadMk4 =            [jhead,   "HEJH16340: JHead MK4 hot end", 64, 5.1,         16,    50, "black", 12,            true, 4.64, 10.19 + 4, [0, 2.94, -5]];
-JHeadMk5 =            [jhead,   "HEJH16340: JHead MK5 hot end", 54, 5.1,         16,    40, "black", 12,            true, 4.64, 9     + 4, [0, 2.38, -5]];
+JHeadMk4 =            [jhead,   "HEJH16340: JHead MK4 hot end", 64, 5.1,         16,    50, "black", 12,            true, 4.64, 10.19 + 4, [0, 2.94, -5],  20, 20];
+JHeadMk5 =            [jhead,   "HEJH16340: JHead MK5 hot end", 54, 5.1,         16,    40, "black", 12,            true, 4.64, 9     + 4, [0, 2.38, -5],  20, 20];
 
-e3dv6 =               [e3d,     "e3d V6 3mm direct",            62, 3.7,         16,  42.7, "lightgrey",  12,       true,    6,        15, [1, 5, -5]];
-e3dv5 =               [e3d,     "e3d V5 3mm direct",            70, 3.7,         16,  50.1, "lightgrey",  12,       true,    6,        15, [1, 5, -5]];
-e3d_clone =           [e3d,     "e3d clone aliexpress",         66, 6.8,         16,    46, "lightgrey",  12,       true,  5.6,        15, [1, 5, -5]];
+e3dv6 =               [e3d,     "e3d V6 3mm direct",            62, 3.7,         16,  42.7, "lightgrey",  12,       true,    6,        15, [1, 5, -5], 15, 25];
+e3dv5 =               [e3d,     "e3d V5 3mm direct",            70, 3.7,         16,  50.1, "lightgrey",  12,       true,    6,        15, [1, 5, -5], 15, 31];
+e3d_clone =           [e3d,     "e3d clone aliexpress",         66, 6.8,         16,    46, "lightgrey",  12,       true,  5.6,        15, [1, 5, -5], 15, 25];
 
 function hot_end_style(type)              = type[0];
 function hot_end_part(type)               = type[1];
@@ -34,5 +34,7 @@ function hot_end_groove_mount(type)       = type[8];
 function hot_end_groove_heigh(type)       = type[9];
 function hot_end_duct_radius(type)        = type[10];
 function hot_end_duct_offset(type)        = type[11];
+function hot_end_duct_height_nozzle(type) = type[12];
+function hot_end_duct_height_fan(type)    = type[13];
 
 function hot_end_length(type) = hot_end_total_length(type) - hot_end_inset(type);

--- a/scad/vitamins/hot_ends.scad
+++ b/scad/vitamins/hot_ends.scad
@@ -10,17 +10,12 @@ Stoffel = 1;
 m90     = 2;
 jhead   = 3;
 
-function jhead_groove() = 4.64;
-function jhead_groove_offset() = 5.1; //4.76;
-
-jhead_inset = jhead_groove_offset();
-
 m90_hot_end_12mm    = [m90,      "HEM90340: Mendel 90 hot end", 57, 10,          12,    40, "tan", 6     + 3/2 - 1, false];
 m90_hot_end_12p5mm  = [m90,      "HEM90340: Mendel 90 hot end", 57, 10,          12.5,  40, "tan", 6.25  + 3/2 - 1, false];
 m90_hot_end_12p75mm = [m90,      "HEM90340: Mendel 90 hot end", 57, 10,          12.75, 40, "tan", 6.375 + 3/2 - 1, false];
 
-JHeadMk4 =            [jhead,   "HEJH16340: JHead MK4 hot end", 64, jhead_inset, 16,    50, "black", 12,            true, 10.19 + 4, [0, 2.94, -5]];
-JHeadMk5 =            [jhead,   "HEJH16340: JHead MK5 hot end", 54, jhead_inset, 16,    40, "black", 12,            true, 9     + 4, [0, 2.38, -5]];
+JHeadMk4 =            [jhead,   "HEJH16340: JHead MK4 hot end", 64, 5.1,         16,    50, "black", 12,            true, 4.64, 10.19 + 4, [0, 2.94, -5]];
+JHeadMk5 =            [jhead,   "HEJH16340: JHead MK5 hot end", 54, 5.1,         16,    40, "black", 12,            true, 4.64, 9     + 4, [0, 2.38, -5]];
 
 function hot_end_style(type)              = type[0];
 function hot_end_part(type)               = type[1];
@@ -29,9 +24,10 @@ function hot_end_inset(type)              = type[3];
 function hot_end_insulator_diameter(type) = type[4];
 function hot_end_insulator_length(type)   = type[5];
 function hot_end_insulator_colour(type)   = type[6];
-function hot_end_screw_pitch(type)        = type[7];
+function hot_end_screw_pitch(type)        = type[7];  // Is groove diameter
 function hot_end_groove_mount(type)       = type[8];
-function hot_end_duct_radius(type)        = type[9];
-function hot_end_duct_offset(type)        = type[10];
+function hot_end_groove_heigh(type)       = type[9];
+function hot_end_duct_radius(type)        = type[10];
+function hot_end_duct_offset(type)        = type[11];
 
 function hot_end_length(type) = hot_end_total_length(type) - hot_end_inset(type);

--- a/scad/vitamins/jhead_hot_end.scad
+++ b/scad/vitamins/jhead_hot_end.scad
@@ -22,8 +22,6 @@ barrel_tap_dia = 5;
 barrel_dia = 6;
 insulator_dia = 12;
 
-function jhead_groove_dia() = 12;
-
 module heater_block(type, resistor, thermistor) {
     color("gold") render(convexity = 10) difference() {
         cube([heater_length(type), heater_width(type), heater_height(type)], center = true);
@@ -82,8 +80,8 @@ module jhead_hot_end(type, exploded = exploded) {
             difference() {
                 cylinder(r = hot_end_insulator_diameter(type) / 2, h = insulator_length);
                 cylinder(r = 3.2 / 2, h = insulator_length * 2 + 1, center = true);
-                translate([0, 0, insulator_length - jhead_groove_offset() - jhead_groove() / 2])
-                    tube(ir = jhead_groove_dia() / 2, or = 17 / 2, h = jhead_groove());
+                translate([0, 0, insulator_length - hot_end_inset(type) - hot_end_groove_heigh(type) / 2])
+                    tube(ir = hot_end_screw_pitch(type) / 2, or = 17 / 2, h = hot_end_groove_heigh(type));
             }
 
         color("gold")  render(convexity = 10) union() {

--- a/scad/wade.scad
+++ b/scad/wade.scad
@@ -12,6 +12,7 @@ use <d-motor_bracket.scad>
 use <vitamins/m90_hot_end.scad>
 use <vitamins/stoffel_hot_end.scad>
 use <vitamins/jhead_hot_end.scad>
+use <vitamins/e3d_hot_end.scad>
 
 spring = false;             // use two nuts or one nut and a spring
 
@@ -480,6 +481,8 @@ module wades_assembly(show_connector = true, show_drive = true) {
                 stoffel_hot_end(hot_end);
             if(hot_end_style(hot_end) == jhead)
                 jhead_hot_end(hot_end, exploded = 0);
+            if(hot_end_style(hot_end) == e3d)
+                e3d_hot_end(hot_end, exploded = 0);
        }
     end("hot_end_assembly");
 

--- a/scad/wade.scad
+++ b/scad/wade.scad
@@ -39,7 +39,7 @@ mount_pitch = 25;
 filament_x = 75;
 filament_z = 13;
 
-extension = max(0, nozzle_length - hot_end_length(hot_end));
+extension = max(0, nozzle_length(hot_end) - hot_end_length(hot_end));
 extension_width = 30;
 
 jhead_screw = M3_cap_screw;

--- a/scad/wade.scad
+++ b/scad/wade.scad
@@ -45,7 +45,7 @@ jhead_screw = M3_cap_screw;
 jhead_screw_length = 16;
 jhead_washer = M4_washer;
 jhead_screw_pitch = max(hot_end_insulator_diameter(hot_end) / 2 + screw_head_radius(jhead_screw),
-                          jhead_groove_dia() / 2 + washer_diameter(jhead_washer) / 2);
+                          hot_end_screw_pitch(hot_end) / 2 + washer_diameter(jhead_washer) / 2);
 
 extension_rad = jhead_screw_pitch + 5;
 extension_clearance = 1;
@@ -214,8 +214,8 @@ module wades_block_stl() {
             rotate([90,0,0]) {
                 if(hot_end_groove_mount(hot_end)) assign(relief = 0.5) {
 
-                    translate([0, 0, -insulator_depth + jhead_groove_offset() / 2 + eta])         // slot for the flange
-                        keyhole(insulator / 2, jhead_groove_offset(), width - filament_z);
+                    translate([0, 0, -insulator_depth + hot_end_inset(hot_end) / 2 + eta])         // slot for the flange
+                        keyhole(insulator / 2, hot_end_inset(hot_end), width - filament_z);
 
                     translate([0, 0, -insulator_depth + relief / 2])
                         keyhole(insulator / 2 + 0.5, relief, width - filament_z);           // relief to avoid corner radius

--- a/scad/x-carriage.scad
+++ b/scad/x-carriage.scad
@@ -270,6 +270,7 @@ fan_x = base_offset;
 fan_y = -(width / 2 + fan_width(part_fan) / 2) - (X_carriage_clearance + belt_width(X_belt) + belt_clearance);
 fan_z = nozzle_length + hot_end_duct_offset(hot_end)[2] - duct_height_fan - fan_depth(part_fan) / 2;
 
+fan_x_duct = fan_x - hot_end_duct_offset(hot_end)[0];
 fan_y_duct = -fan_y + hot_end_duct_offset(hot_end)[1];
 
 module throat(inner) {
@@ -285,10 +286,10 @@ module throat(inner) {
 module neck(inner) {
     iw = 2 * (fan_hole_pitch(part_fan) - fan_screw_boss_r) - 3;
     if(inner)
-        translate([fan_x - iw / 2, fan_y_duct - fan_bore(part_fan) / 2, duct_wall])
+        translate([fan_x_duct - iw / 2, fan_y_duct - fan_bore(part_fan) / 2, duct_wall])
             cube([iw, 2 * eta, duct_height_fan - duct_wall - duct_top_thickness]);
     else
-        translate([fan_x - fan_width / 2, fan_y_duct - fan_width / 2, 0])
+        translate([fan_x_duct - fan_width / 2, fan_y_duct - fan_width / 2, 0])
             cube([fan_width, 2 * eta, duct_height_fan]);
 }
 
@@ -302,7 +303,7 @@ module x_carriage_fan_duct_stl() {
                     // fan input
                     hull() {
                         for(side = [-1, 1])
-                            translate([fan_x + side * fan_hole_pitch(part_fan), fan_y_duct + fan_hole_pitch(part_fan), 0])
+                            translate([fan_x_duct + side * fan_hole_pitch(part_fan), fan_y_duct + fan_hole_pitch(part_fan), 0])
                                 cylinder(r = fan_screw_boss_r, h = duct_height_fan);
                         neck(false);
                     }
@@ -330,7 +331,7 @@ module x_carriage_fan_duct_stl() {
 
                 // fan entrance
                 hull() {
-                    translate([fan_x, fan_y_duct, duct_wall + duct_height_fan - duct_wall - duct_top_thickness])
+                    translate([fan_x_duct, fan_y_duct, duct_wall + duct_height_fan - duct_wall - duct_top_thickness])
                         rotate([180, 0, 0])
                             rounded_cylinder(r = fan_bore(part_fan) / 2, h = duct_height_fan - duct_wall - duct_top_thickness, r2 = duct_height_fan / 2);
 
@@ -338,7 +339,7 @@ module x_carriage_fan_duct_stl() {
                 }
                 translate([0, 0, duct_height_fan - duct_wall - duct_top_thickness - 1])
                     hull() {
-                        translate([fan_x, fan_y_duct, duct_wall])
+                        translate([fan_x_duct, fan_y_duct, duct_wall])
                             cylinder(r = fan_bore(part_fan) / 2, h = duct_height_fan - duct_wall - duct_top_thickness);
 
                         neck(true);
@@ -371,13 +372,13 @@ module x_carriage_fan_duct_stl() {
                     }
             }
             for(side = [-1, 1])
-                translate([fan_x + side * fan_hole_pitch(part_fan), fan_y_duct - fan_hole_pitch(part_fan), 0])
+                translate([fan_x_duct + side * fan_hole_pitch(part_fan), fan_y_duct - fan_hole_pitch(part_fan), 0])
                     cylinder(r = fan_screw_boss_r, h = duct_height_fan);
         }
         //
         // Fan screw nut traps
         //
-        translate([fan_x, fan_y_duct, -fan_depth(part_fan) / 2])
+        translate([fan_x_duct, fan_y_duct, -fan_depth(part_fan) / 2])
             fan_hole_positions(part_fan) group() {
                 nut_trap(screw_clearance_radius(fan_screw), nut_radius(screw_nut(fan_screw)), duct_height_fan - fan_nut_trap_thickness, supported = true);
                 nut_trap(0, nut_radius(screw_nut(fan_screw)) + 0.15, duct_height_fan - fan_nut_trap_thickness - nut_trap_depth(fan_nut));

--- a/scad/x-carriage.scad
+++ b/scad/x-carriage.scad
@@ -258,7 +258,9 @@ front_nut_y = - width / 2 + wall;
 gap = 6;
 taper_angle = 30;
 nozzle_height = 6;
-duct_height = 20;
+duct_height_nozzle = 20;   // Thickness on the exit side
+duct_height_fan = 20; // Thickness on the fan side
+
 ir = hot_end_duct_radius(hot_end);
 or = ir + duct_wall + gap + duct_wall;
 skew = nozzle_height * tan(taper_angle);
@@ -266,7 +268,7 @@ throat_width = (or + skew) * 2;
 
 fan_x = base_offset;
 fan_y = -(width / 2 + fan_width(part_fan) / 2) - (X_carriage_clearance + belt_width(X_belt) + belt_clearance);
-fan_z = nozzle_length + hot_end_duct_offset(hot_end)[2] - duct_height - fan_depth(part_fan) / 2;
+fan_z = nozzle_length + hot_end_duct_offset(hot_end)[2] - duct_height_fan - fan_depth(part_fan) / 2;
 
 fan_y_duct = -fan_y + hot_end_duct_offset(hot_end)[1];
 
@@ -274,10 +276,10 @@ module throat(inner) {
     y = or + skew - duct_wall;
     if(inner)
         translate([-throat_width / 2 + duct_wall, y, nozzle_height])
-            cube([throat_width - 2 * duct_wall, 2 * eta, (duct_height - nozzle_height) - duct_top_thickness]);
+            cube([throat_width - 2 * duct_wall, 2 * eta, (duct_height_nozzle - nozzle_height) - duct_top_thickness]);
     else
         translate([-throat_width / 2, y - duct_wall, 0])
-            cube([throat_width, 2 * eta, duct_height]);
+            cube([throat_width, 2 * eta, duct_height_nozzle]);
 }
 
 module neck(inner) {
@@ -287,7 +289,7 @@ module neck(inner) {
             cube([iw, 2 * eta, duct_height_fan - duct_wall - duct_top_thickness]);
     else
         translate([fan_x - fan_width / 2, fan_y_duct - fan_width / 2, 0])
-            cube([fan_width, 2 * eta, duct_height]);
+            cube([fan_width, 2 * eta, duct_height_fan]);
 }
 
 module x_carriage_fan_duct_stl() {
@@ -301,7 +303,7 @@ module x_carriage_fan_duct_stl() {
                     hull() {
                         for(side = [-1, 1])
                             translate([fan_x + side * fan_hole_pitch(part_fan), fan_y_duct + fan_hole_pitch(part_fan), 0])
-                                cylinder(r = fan_screw_boss_r, h = duct_height);
+                                cylinder(r = fan_screw_boss_r, h = duct_height_fan);
                         neck(false);
                     }
                     // neck
@@ -315,7 +317,7 @@ module x_carriage_fan_duct_stl() {
                         union() {
                             cylinder(r1 = or, r2 = or + skew, h = nozzle_height);
                             translate([0, 0, nozzle_height - eta])
-                                cylinder(r = or + skew, h = duct_height - nozzle_height);
+                                cylinder(r = or + skew, h = duct_height_nozzle - nozzle_height);
                         }
                         throat(false);
                     }
@@ -324,20 +326,20 @@ module x_carriage_fan_duct_stl() {
                 translate([0, 0,  -2 * eta])
                     cylinder(r1 = ir, r2 = ir + skew, h = nozzle_height + 4 * eta);
                 translate([0, 0, nozzle_height - 2 * eta])
-                    cylinder(r = ir + skew, h = duct_height - nozzle_height + 4 * eta);
+                    cylinder(r = ir + skew, h = duct_height_fan - nozzle_height + 4 * eta);
 
                 // fan entrance
                 hull() {
-                    translate([fan_x, fan_y_duct, duct_wall + duct_height - duct_wall - duct_top_thickness])
+                    translate([fan_x, fan_y_duct, duct_wall + duct_height_fan - duct_wall - duct_top_thickness])
                         rotate([180, 0, 0])
-                            rounded_cylinder(r = fan_bore(part_fan) / 2, h = duct_height - duct_wall - duct_top_thickness, r2 = duct_height / 2);
+                            rounded_cylinder(r = fan_bore(part_fan) / 2, h = duct_height_fan - duct_wall - duct_top_thickness, r2 = duct_height_fan / 2);
 
                     neck(true);
                 }
-                translate([0, 0, duct_height - duct_wall - duct_top_thickness - 1])
+                translate([0, 0, duct_height_fan - duct_wall - duct_top_thickness - 1])
                     hull() {
                         translate([fan_x, fan_y_duct, duct_wall])
-                            cylinder(r = fan_bore(part_fan) / 2, h = duct_height - duct_wall - duct_top_thickness);
+                            cylinder(r = fan_bore(part_fan) / 2, h = duct_height_fan - duct_wall - duct_top_thickness);
 
                         neck(true);
                     }
@@ -355,7 +357,7 @@ module x_carriage_fan_duct_stl() {
                             cylinder(r1 = or - duct_wall, r2 = or + skew - duct_wall, h = nozzle_height);
                             hull() {
                                 translate([0, 0, nozzle_height - 2 * eta])
-                                    cylinder(r = or + skew - duct_wall, h = duct_height - nozzle_height - duct_top_thickness);
+                                    cylinder(r = or + skew - duct_wall, h = duct_height_nozzle - nozzle_height - duct_top_thickness);
                                 throat(true);
                             }
                         }
@@ -364,27 +366,27 @@ module x_carriage_fan_duct_stl() {
                             cylinder(r1 = ir + duct_wall, r2 = ir + skew + duct_wall, h = nozzle_height + 4 * eta);
 
                         translate([0, 0, nozzle_height - 2 * eta])
-                            cylinder(r = ir + skew + duct_wall, h = duct_height - nozzle_height + 4 * eta);
+                            cylinder(r = ir + skew + duct_wall, h = duct_height_nozzle - nozzle_height + 4 * eta);
 
                     }
             }
             for(side = [-1, 1])
                 translate([fan_x + side * fan_hole_pitch(part_fan), fan_y_duct - fan_hole_pitch(part_fan), 0])
-                    cylinder(r = fan_screw_boss_r, h = duct_height);
+                    cylinder(r = fan_screw_boss_r, h = duct_height_fan);
         }
         //
         // Fan screw nut traps
         //
         translate([fan_x, fan_y_duct, -fan_depth(part_fan) / 2])
             fan_hole_positions(part_fan) group() {
-                nut_trap(screw_clearance_radius(fan_screw), nut_radius(screw_nut(fan_screw)), duct_height - fan_nut_trap_thickness, supported = true);
-                nut_trap(0, nut_radius(screw_nut(fan_screw)) + 0.15, duct_height - fan_nut_trap_thickness - nut_trap_depth(fan_nut));
+                nut_trap(screw_clearance_radius(fan_screw), nut_radius(screw_nut(fan_screw)), duct_height_fan - fan_nut_trap_thickness, supported = true);
+                nut_trap(0, nut_radius(screw_nut(fan_screw)) + 0.15, duct_height_fan - fan_nut_trap_thickness - nut_trap_depth(fan_nut));
             }
         //
         // Cold end cooling vent
         //
         rotate([0, 0, atan2(-fan_x, -fan_y)])
-            translate([0, ir + skew, duct_height - duct_top_thickness - 3])
+            translate([0, ir + skew, duct_height_nozzle - duct_top_thickness - 3])
                 rotate([90, 0, 0])
                     teardrop(r = 4.5 / 2, h = 10, center = true);
     }

--- a/scad/x-carriage.scad
+++ b/scad/x-carriage.scad
@@ -237,6 +237,7 @@ module x_belt_tensioner_stl()
 }
 
 duct_wall = 2 * 0.35 * 1.5;
+duct_bottom_thickness = 3*layer_height;
 duct_top_thickness = 4*layer_height;
 fan_nut_trap_thickness = 4;
 fan_bracket_thickness = 3;
@@ -286,8 +287,8 @@ module throat(inner) {
 module neck(inner) {
     iw = 2 * (fan_hole_pitch(part_fan) - fan_screw_boss_r) - 3;
     if(inner)
-        translate([fan_x_duct - iw / 2, fan_y_duct - fan_bore(part_fan) / 2, duct_wall])
-            cube([iw, 2 * eta, duct_height_fan - duct_wall - duct_top_thickness]);
+        translate([fan_x_duct - iw / 2, fan_y_duct - fan_bore(part_fan) / 2, duct_bottom_thickness])
+            cube([iw, 2 * eta, duct_height_fan - duct_bottom_thickness - duct_top_thickness]);
     else
         translate([fan_x_duct - fan_width / 2, fan_y_duct - fan_bore(part_fan) / 2, 0])
             cube([fan_width, 2 * eta, duct_height_fan]);
@@ -333,7 +334,7 @@ module x_carriage_fan_duct_stl() {
                 hull() {
                     translate([fan_x_duct, fan_y_duct, duct_wall + duct_height_fan - duct_wall - duct_top_thickness])
                         rotate([180, 0, 0])
-                            rounded_cylinder(r = fan_bore(part_fan) / 2, h = duct_height_fan - duct_wall - duct_top_thickness, r2 = duct_height_fan / 2);
+                            rounded_cylinder(r = fan_bore(part_fan) / 2, h = duct_height_fan - duct_bottom_thickness - duct_top_thickness, r2 = duct_height_fan / 2);
 
                     neck(true);
                 }

--- a/scad/x-carriage.scad
+++ b/scad/x-carriage.scad
@@ -279,7 +279,7 @@ module throat(inner) {
         translate([-throat_width / 2 + duct_wall, y, nozzle_height])
             cube([throat_width - 2 * duct_wall, 2 * eta, (duct_height_nozzle - nozzle_height) - duct_top_thickness]);
     else
-        translate([-throat_width / 2, y - duct_wall, 0])
+        translate([-throat_width / 2, y, 0])
             cube([throat_width, 2 * eta, duct_height_nozzle]);
 }
 
@@ -289,7 +289,7 @@ module neck(inner) {
         translate([fan_x_duct - iw / 2, fan_y_duct - fan_bore(part_fan) / 2, duct_wall])
             cube([iw, 2 * eta, duct_height_fan - duct_wall - duct_top_thickness]);
     else
-        translate([fan_x_duct - fan_width / 2, fan_y_duct - fan_width / 2, 0])
+        translate([fan_x_duct - fan_width / 2, fan_y_duct - fan_bore(part_fan) / 2, 0])
             cube([fan_width, 2 * eta, duct_height_fan]);
 }
 

--- a/scad/x-carriage.scad
+++ b/scad/x-carriage.scad
@@ -387,6 +387,7 @@ module x_carriage_fan_duct_stl() {
         //
         // Cold end cooling vent
         //
+        if (hot_end_style(hot_end) != e3d)
         rotate([0, 0, atan2(-fan_x, -fan_y)])
             translate([0, ir + skew, duct_height_nozzle - duct_top_thickness - 3])
                 rotate([90, 0, 0])

--- a/scad/x-carriage.scad
+++ b/scad/x-carriage.scad
@@ -237,7 +237,7 @@ module x_belt_tensioner_stl()
 }
 
 duct_wall = 2 * 0.35 * 1.5;
-top_thickness = 2;
+duct_top_thickness = 4*layer_height;
 fan_nut_trap_thickness = 4;
 fan_bracket_thickness = 3;
 
@@ -274,7 +274,7 @@ module throat(inner) {
     y = or + skew - duct_wall;
     if(inner)
         translate([-throat_width / 2 + duct_wall, y, nozzle_height])
-            cube([throat_width - 2 * duct_wall, 2 * eta, (duct_height - nozzle_height) - top_thickness]);
+            cube([throat_width - 2 * duct_wall, 2 * eta, (duct_height - nozzle_height) - duct_top_thickness]);
     else
         translate([-throat_width / 2, y - duct_wall, 0])
             cube([throat_width, 2 * eta, duct_height]);
@@ -284,7 +284,7 @@ module neck(inner) {
     iw = 2 * (fan_hole_pitch(part_fan) - fan_screw_boss_r) - 3;
     if(inner)
         translate([fan_x - iw / 2, fan_y_duct - fan_bore(part_fan) / 2, duct_wall])
-            cube([iw, 2 * eta, duct_height - duct_wall - top_thickness]);
+            cube([iw, 2 * eta, duct_height_fan - duct_wall - duct_top_thickness]);
     else
         translate([fan_x - fan_width / 2, fan_y_duct - fan_width / 2, 0])
             cube([fan_width, 2 * eta, duct_height]);
@@ -328,16 +328,16 @@ module x_carriage_fan_duct_stl() {
 
                 // fan entrance
                 hull() {
-                    translate([fan_x, fan_y_duct, duct_wall + duct_height - duct_wall - top_thickness])
+                    translate([fan_x, fan_y_duct, duct_wall + duct_height - duct_wall - duct_top_thickness])
                         rotate([180, 0, 0])
-                            rounded_cylinder(r = fan_bore(part_fan) / 2, h = duct_height - duct_wall - top_thickness, r2 = duct_height / 2);
+                            rounded_cylinder(r = fan_bore(part_fan) / 2, h = duct_height - duct_wall - duct_top_thickness, r2 = duct_height / 2);
 
                     neck(true);
                 }
-                translate([0, 0, duct_height - duct_wall - top_thickness - 1])
+                translate([0, 0, duct_height - duct_wall - duct_top_thickness - 1])
                     hull() {
                         translate([fan_x, fan_y_duct, duct_wall])
-                            cylinder(r = fan_bore(part_fan) / 2, h = duct_height - duct_wall - top_thickness);
+                            cylinder(r = fan_bore(part_fan) / 2, h = duct_height - duct_wall - duct_top_thickness);
 
                         neck(true);
                     }
@@ -355,7 +355,7 @@ module x_carriage_fan_duct_stl() {
                             cylinder(r1 = or - duct_wall, r2 = or + skew - duct_wall, h = nozzle_height);
                             hull() {
                                 translate([0, 0, nozzle_height - 2 * eta])
-                                    cylinder(r = or + skew - duct_wall, h = duct_height - nozzle_height - 5 * layer_height);
+                                    cylinder(r = or + skew - duct_wall, h = duct_height - nozzle_height - duct_top_thickness);
                                 throat(true);
                             }
                         }
@@ -384,7 +384,7 @@ module x_carriage_fan_duct_stl() {
         // Cold end cooling vent
         //
         rotate([0, 0, atan2(-fan_x, -fan_y)])
-            translate([0, ir + skew, duct_height - top_thickness - 3])
+            translate([0, ir + skew, duct_height - duct_top_thickness - 3])
                 rotate([90, 0, 0])
                     teardrop(r = 4.5 / 2, h = 10, center = true);
     }
@@ -443,7 +443,7 @@ module x_carriage_fan_bracket_stl() {
             //
             // mounting screw holes
             //
-            translate([side * front_nut_pitch, 0, max(h - top_thickness - front_nut_z - bodge, fan_bracket_thickness + washer_diameter(M3_washer) / 2) + h / 2])
+            translate([side * front_nut_pitch, 0, max(h - duct_top_thickness - front_nut_z - bodge, fan_bracket_thickness + washer_diameter(M3_washer) / 2) + h / 2])
                 rotate([90, 0, 0])
                     vertical_tearslot(h = 100, l = h, r = M3_clearance_radius, center = true);
             //
@@ -625,7 +625,7 @@ module x_carriage_fan_assembly() {
                         screw_and_washer(fan_screw, fan_screw_length);
             fan_hole_positions(part_fan) group() {
                 rotate([180, 0, 0])
-                    translate([0, 0, fan_depth(part_fan) + top_thickness + 30 * exploded])
+                    translate([0, 0, fan_depth(part_fan) + duct_top_thickness + 30 * exploded])
                         nut(fan_nut, true);
             }
             translate([0, 0, fan_depth(part_fan) / 2])
@@ -658,7 +658,7 @@ module x_carriage_assembly(show_extruder = true, show_fan = true) {
     // Fan bracket screws
     //
     for(side = [-1, 1])
-        translate([fan_x + side * front_nut_pitch, -width / 2 - fan_bracket_thickness, front_nut_z + top_thickness]) {
+        translate([fan_x + side * front_nut_pitch, -width / 2 - fan_bracket_thickness, front_nut_z + duct_top_thickness]) {
             rotate([90, 0, 0])
                 screw_and_washer(M3_cap_screw, 10);
 

--- a/scad/x-carriage.scad
+++ b/scad/x-carriage.scad
@@ -269,7 +269,7 @@ throat_width = (or + skew) * 2;
 
 fan_x = base_offset;
 fan_y = -(width / 2 + fan_width(part_fan) / 2) - (2*X_carriage_clearance + belt_width(X_belt) + belt_clearance);
-fan_z = nozzle_length + hot_end_duct_offset(hot_end)[2] - duct_height_fan - fan_depth(part_fan) / 2;
+fan_z = nozzle_length(hot_end) + hot_end_duct_offset(hot_end)[2] - duct_height_fan - fan_depth(part_fan) / 2;
 
 fan_x_duct = fan_x - hot_end_duct_offset(hot_end)[0];
 fan_y_duct = -fan_y + hot_end_duct_offset(hot_end)[1];
@@ -617,7 +617,7 @@ module x_carriage_stl(){
 module x_carriage_fan_assembly() {
     assembly("x_carriage_fan_assembly");
 
-    translate([0, 0, nozzle_length + exploded * 15] + hot_end_duct_offset(hot_end))
+    translate([0, 0, nozzle_length(hot_end) + exploded * 15] + hot_end_duct_offset(hot_end))
         rotate([180, 0, 0])
             color(plastic_part_color("lime")) render() x_carriage_fan_duct_stl();
 

--- a/scad/x-carriage.scad
+++ b/scad/x-carriage.scad
@@ -267,7 +267,7 @@ skew = nozzle_height * tan(taper_angle);
 throat_width = (or + skew) * 2;
 
 fan_x = base_offset;
-fan_y = -(width / 2 + fan_width(part_fan) / 2) - (X_carriage_clearance + belt_width(X_belt) + belt_clearance);
+fan_y = -(width / 2 + fan_width(part_fan) / 2) - (2*X_carriage_clearance + belt_width(X_belt) + belt_clearance);
 fan_z = nozzle_length + hot_end_duct_offset(hot_end)[2] - duct_height_fan - fan_depth(part_fan) / 2;
 
 fan_x_duct = fan_x - hot_end_duct_offset(hot_end)[0];

--- a/scad/x-carriage.scad
+++ b/scad/x-carriage.scad
@@ -259,8 +259,8 @@ front_nut_y = - width / 2 + wall;
 gap = 6;
 taper_angle = 30;
 nozzle_height = 6;
-duct_height_nozzle = 20;   // Thickness on the exit side
-duct_height_fan = 20; // Thickness on the fan side
+duct_height_nozzle = hot_end_duct_height_nozzle(hot_end);   // Thickness on the exit side
+duct_height_fan = hot_end_duct_height_fan(hot_end); // Thickness on the fan side
 
 ir = hot_end_duct_radius(hot_end);
 or = ir + duct_wall + gap + duct_wall;


### PR DESCRIPTION
This pull request replaces this one https://github.com/nophead/Mendel90/pull/56.

It allows the E3D head to be used, and adapt the fan-duct accordingly so that it fits.
The fan duct is kept the same when jhead is selected (except a few internal fixes).

