### PR TITLE
Slightly Better Tears

### DIFF
--- a/scad/utils/teardrops.scad
+++ b/scad/utils/teardrops.scad
@@ -8,39 +8,33 @@
 // For making horizontal holes that don't need support material
 // Small holes can get away without it but they print better with truncated teardrops
 //
-module teardrop_2D(r, truncate = true) {
-    difference() {
-        union() {
-            circle(r = r, center = true);
-            translate([0,r / sqrt(2),0])
-                rotate([0,0,45])
-                    square([r, r], center = true);
-        }
-        if(truncate)
-            translate([0, r * 2, 0])
-                square([2 * r, 2 * r], center = true);
+module teardrop_2D(r) {
+    hull() {
+        circle(r = r, center = true);
+        translate([0, r/2])
+            square([2*r*(2*cos(45)-1), r], center = true);
     }
 }
 
-module teardrop(h, r, center, truncate = true)
+module teardrop(h, r, center)
     render(convexity = 5) linear_extrude(height = h, convexity = 2, center = center)
-        teardrop_2D(r, truncate);
+        teardrop_2D(r);
 
-module teardrop_plus(h, r, center, truncate = true)
-    teardrop(h, r + layer_height / 4, center, truncate);
+module teardrop_plus(h, r, center)
+    teardrop(h, r + layer_height / 4, center);
 
 
 module tearslot(h, r, w, center)
     linear_extrude(height = h, convexity = 6, center = center)
         hull() {
-            translate([-w/2,0,0]) teardrop_2D(r, true);
-            translate([ w/2,0,0]) teardrop_2D(r, true);
+            translate([-w/2,0,0]) teardrop_2D(r);
+            translate([ w/2,0,0]) teardrop_2D(r);
         }
 
 module vertical_tearslot(h, r, l, center = true)
     linear_extrude(height = h, convexity = 6, center = center)
         hull() {
-            translate([0, l / 2]) teardrop_2D(r, true);
+            translate([0, l / 2]) teardrop_2D(r);
             translate([0, -l / 2, 0])
                 circle(r = r, center = true);
         }


### PR DESCRIPTION
I saw your [question](http://forum.openscad.org/truncated-teardrop-countersink-td1606.html) from a few years ago while figuring out how to model this and decided to see how you had answered it. Here is a more elegant solution. It has the advantage of being more exact where, in the model you are currently using, the corners of the square join the circle - it is possible to have small (probably irrelevent) errors due to the approximation of the square root of two. This is avoided in this model with the use of the hull method, while not sacrificing the accuracy of the truncation. 